### PR TITLE
Site icon as image & Assignment list

### DIFF
--- a/assignments-list/README.md
+++ b/assignments-list/README.md
@@ -1,0 +1,2 @@
+This snippet displays a list of open assignments for a student and display them in a table
+

--- a/assignments-list/snippet.html
+++ b/assignments-list/snippet.html
@@ -1,0 +1,63 @@
+<script>
+var $assignmentsList, user;
+
+// Create a div, and give it is unqiue ID
+$assignmentsList = $("<div>", {
+        id: Frog.Utilities.generateSimpleId()
+    }
+);
+
+// Add a table to the div
+$assignmentsList.html(
+    '<b>Your open assignments:</b>'+
+    '<table class="table" id="your_assignments">'+
+        '<tr>'+
+            '<th>Subject</th>'+
+            '<th>Title</th>'+
+            '<th>Due Date</th>'+
+            '<th>Instructions</th>'+
+        '</tr>'+
+    '</table>'
+);
+
+// Use Frog's API to get the logged in student
+user = FrogOS.getUser();
+
+// Use Frog's assignmentreports.getData to get 15 assignments for the logged in student.
+Frog.Model
+    .api('assignmentreports.getData', {
+        filter: { status: "open" },
+        limit: 15,
+        offset: 0,
+        options: { child_uuid: user.uuid },
+        report_name: "student.assignments"
+    }).done(function(assignmentResponse) {
+
+        // Loop through all the responses
+        assignmentResponse.data.forEach(function(work) {
+
+            // Use monment.js to convert the due date timestamp to a human-readable format
+            var dueDate = moment.unix(work.due_date).format("DD/MM/YY");
+
+            // Find the table in the DIV created above and add in the various fields from the API's response as a  new row
+            $assignmentsList.find('tbody')
+                .append(
+                    '<tr>'+
+                         '<td>'+
+                         work.subject_name+
+                         '</td><td><b>'+
+                         work.assignment_name+
+                         '</b></td><td>'+
+                         work.instructions+
+                         '</td><td>'+
+                         dueDate+
+                         '</td>'+
+                    '</tr>'
+                );
+        }
+    );
+});
+
+
+arguments[0].append($assignmentsList);
+</script>

--- a/site-icon-as-image/README.md
+++ b/site-icon-as-image/README.md
@@ -1,0 +1,4 @@
+Site Icon as Image
+
++Drop this code into your site in an HTML widget
++As the site loads, it will display the icon

--- a/site-icon-as-image/snippet.html
+++ b/site-icon-as-image/snippet.html
@@ -1,0 +1,28 @@
+<script>
+var siteImLookingAt, siteCore, siteLink, $newDiv;
+
+// arguments[0] is the HTML widget your code is sitting in.  Using this, it is possible to identify the site containing the HTML widget
+siteImLookingAt = arguments[0].closest('.ui-dialog').find('.sites_core').data('controllers');
+
+siteCore = siteImLookingAt.sites_core;
+
+siteLink = siteImLookingAt && siteCore && siteCore.options.site;
+
+// This code below uses jQuery to create a DIV and uses one of Frog's utitilies to create a unique ID, allowing jQuery to append to the div, $newDiv.
+$newDiv = $("<div>", {
+        id: Frog.Utilities.generateSimpleId()
+    }
+);
+
+// Knowing the siteLink from the above, we can use Frog's API sites.getInfo to return the site's icon
+Frog.Model
+    .api('sites.getInfo', {
+        link: siteLink,
+        method: "sites.getInfo"
+    }).done(function(siteResponse) {
+        $newDiv.html("<img src='"+siteResponse.data.icon+"'>");
+    });
+
+arguments[0].append($newDiv);
+
+</script>


### PR DESCRIPTION
- Site icon as image & Assignment list

Two snippets:

Site icon displays a site's icon as its image

Assignment List lists out the assignments for a student without them
accessing the app
- Added correct code for assignments

and improved site icon code based on feedback
- Updated based on feedback

Site icon is commented, assignments list rewritten for student accessing
latest assignments
- Updated to tidy up styling and add comments
